### PR TITLE
fetching a dictionary type result with column name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,7 @@ The library implements the standard DB API 2.0 interface, so it can be
 used the same way you would use any other SQL database from Python, for example::
 
     import phoenixdb
+    import phoenixdb.cursor
 
     database_url = 'http://localhost:8765/'
     conn = phoenixdb.connect(database_url, autocommit=True)
@@ -38,6 +39,11 @@ used the same way you would use any other SQL database from Python, for example:
     cursor.execute("UPSERT INTO users VALUES (?, ?)", (1, 'admin'))
     cursor.execute("SELECT * FROM users")
     print cursor.fetchall()
+
+    cursor = conn.cursor(cursor_factory=phoenixdb.cursor.DictCursor)
+    cursor.execute("SELECT * FROM users WHERE id=1")
+    print cursor.fetchone()['USERNAME']
+
 
 Setting up a development environment
 ------------------------------------

--- a/phoenixdb/__init__.py
+++ b/phoenixdb/__init__.py
@@ -56,6 +56,9 @@ def connect(url, max_retries=None, **kwargs):
     :param max_retries:
         The maximum number of retries in case there is a connection error.
 
+    :param cursor_factory:
+        If specified, the connection's :attr:`~phoenixdb.connection.Connection.cursor_factory` is set to it.
+
     :returns:
         :class:`~phoenixdb.connection.Connection` object.
     """

--- a/phoenixdb/cursor.py
+++ b/phoenixdb/cursor.py
@@ -257,7 +257,7 @@ class Cursor(object):
                 tmp_row.append(value)
         return tmp_row
 
-    def fetchone(self):
+    def fetchone(self, doc=False):
         if self._frame is None:
             raise ProgrammingError('no select statement was executed')
         if self._pos is None:
@@ -269,28 +269,37 @@ class Cursor(object):
             self._pos = None
             if not self._frame.done:
                 self._fetch_next_frame()
-        return row
+        if doc:
+            return self.docResult(row=row)
+        else:
+            return row
 
-    def fetchmany(self, size=None):
+    def fetchmany(self, size=None, doc=False):
         if size is None:
             size = self.arraysize
         rows = []
         while size > 0:
-            row = self.fetchone()
+            row = self.fetchone(doc=doc)
             if row is None:
                 break
             rows.append(row)
             size -= 1
         return rows
 
-    def fetchall(self):
+    def fetchall(self, doc=False):
         rows = []
         while True:
-            row = self.fetchone()
+            row = self.fetchone(doc=doc)
             if row is None:
                 break
             rows.append(row)
         return rows
+    
+    def docResult(self, row):
+        d = {}
+        for ind, val in enumerate(row):
+            d[self._signature.columns.__getitem__(ind).column_name] = val
+        return d
 
     def setinputsizes(self, sizes):
         pass

--- a/phoenixdb/tests/test_db.py
+++ b/phoenixdb/tests/test_db.py
@@ -1,5 +1,6 @@
 import unittest
 import phoenixdb
+import phoenixdb.cursor
 from phoenixdb.tests import TEST_DB_URL
 
 
@@ -33,3 +34,32 @@ class PhoenixDatabaseTest(unittest.TestCase):
             cursor.itersize = 4
             cursor.execute("SELECT * FROM test WHERE id>? ORDER BY id", [1])
             self.assertEqual(cursor.fetchall(), [[i, 'text {}'.format(i)] for i in range(2, 10)])
+
+    def _check_dict_cursor(self, cursor):
+        cursor.execute("DROP TABLE IF EXISTS test")
+        cursor.execute("CREATE TABLE test (id INTEGER PRIMARY KEY, text VARCHAR)")
+        cursor.execute("UPSERT INTO test VALUES (?, ?)", [1, 'text 1'])
+        cursor.execute("SELECT * FROM test ORDER BY id")
+        self.assertEqual(cursor.fetchall(), [{'ID': 1, 'TEXT': 'text 1'}])
+
+    def test_dict_cursor_default_parameter(self):
+        db = phoenixdb.connect(TEST_DB_URL, autocommit=True, cursor_factory=phoenixdb.cursor.DictCursor)
+        self.addCleanup(db.close)
+
+        with db.cursor() as cursor:
+            self._check_dict_cursor(cursor)
+
+    def test_dict_cursor_default_attribute(self):
+        db = phoenixdb.connect(TEST_DB_URL, autocommit=True)
+        db.cursor_factory = phoenixdb.cursor.DictCursor
+        self.addCleanup(db.close)
+
+        with db.cursor() as cursor:
+            self._check_dict_cursor(cursor)
+
+    def test_dict_cursor(self):
+        db = phoenixdb.connect(TEST_DB_URL, autocommit=True)
+        self.addCleanup(db.close)
+
+        with db.cursor(cursor_factory=phoenixdb.cursor.DictCursor) as cursor:
+            self._check_dict_cursor(cursor)


### PR DESCRIPTION
The result we were getting were of list format and difficult to map the column names, added a new method docResult to give a dictionary type result. By default it'll be a list like it is now, but if you give doc=True in fetchall(), fetchmany() or fetchone(), it'll return a dictionary type result.