### PR TITLE
remove error message to stdout on python shutdown

### DIFF
--- a/phoenixdb/connection.py
+++ b/phoenixdb/connection.py
@@ -57,8 +57,12 @@ class Connection(object):
         self.set_session(**self._filtered_args)
 
     def __del__(self):
-        if not self._closed:
-            self.close()
+        try:
+            if not self._closed:
+                self.close()
+        except ImportError:
+            # Pass if Python is shutting down when this is called
+            pass
 
     def __enter__(self):
         return self


### PR DESCRIPTION
This resolves Issue #18 by catching ImportError on exit. Testing for `del conn` provides successful connection closure. Testing for sudden shutdown from sys.exit and ctrl+d causes no error message in stdout.